### PR TITLE
Fix for invisible GitHub link, developers and translators (en, pl, de language)

### DIFF
--- a/FlymFork/src/main/res/values-de/strings.xml
+++ b/FlymFork/src/main/res/values-de/strings.xml
@@ -36,7 +36,7 @@
     <a href=\"https://handynewsreader.blogspot.com/\">Webseite</a>  <br/>
 
     <br/>
-    Link zum <a href=\"https://play.google.com/store/apps/details?id=ru.yanus171.feedexfork\">Google Play</a>  <br/>
+    Link zu <a href=\"https://play.google.com/store/apps/details?id=ru.yanus171.feedexfork\">Google Play</a>  <br/>
 
     <br/>
     Link zur Entwicklercommunity <a href=\"https://forum.xda-developers.com/android/apps-games/app-flym-fork-rss-reader-t3802126\">XDA </a>  <br/>
@@ -59,7 +59,7 @@
     • neue Ideen und Vorschläge <a href=\"mailto:workyalex@mail.ru?subject=Handy News Reader idea\">senden</a>
 
     <br/>
-    Quellen finden Sie bei <a href=\"https://github.com/yanus171/Flym">GitHub</a> <br/>
+    Quellen finden Sie bei <a href=\"https://github.com/yanus171/Flym\">GitHub</a> <br/>
 
     <br/>
     <b>Entwickler</b><br/>

--- a/FlymFork/src/main/res/values-pl/strings.xml
+++ b/FlymFork/src/main/res/values-pl/strings.xml
@@ -57,7 +57,7 @@
     - <a href=\"mailto:workyalex@mail.ru?subject=Handy News Reader idea\">zasugeruj</a> pomysł
 
     <br/>
-    Źródła na <a href=\"https://github.com/yanus171/Flym">GitHub</a> <br/>
+    Źródła na <a href=\"https://github.com/yanus171/Flym\">GitHub</a> <br/>
 
     <br/>
     <b>Deweloperzy:</b><br/>

--- a/FlymFork/src/main/res/values/strings.xml
+++ b/FlymFork/src/main/res/values/strings.xml
@@ -57,7 +57,7 @@
     - <a href=\"mailto:workyalex@mail.ru?subject=Handy News Reader idea\">suggest</a> an idea
 
     <br/>
-    Sources on <a href=\"https://github.com/yanus171/Flym">GitHub</a> <br/>
+    Sources on <a href=\"https://github.com/yanus171/Flym\">GitHub</a> <br/>
 
     <br/>
     <b>Developers:</b><br/>


### PR DESCRIPTION
some quotation marks were unescaped