### PR TITLE
Only enable WebView file access when a custom font is selected

### DIFF
--- a/FlymFork/src/main/java/ru/yanus171/feedexfork/view/WebViewExtended.java
+++ b/FlymFork/src/main/java/ru/yanus171/feedexfork/view/WebViewExtended.java
@@ -99,10 +99,18 @@ public class WebViewExtended extends WebView implements Handler.Callback {
     public static final String NO_MENU = "NO_MENU_";
     public static final String BASE_URL = "";
 
-    private static boolean NeedsFileAccessForCustomFont() {
+    private static boolean NeedsFileAccess() {
+        // Custom fonts are loaded via @font-face src: url('file://<fonts dir>/...').
         String fontName = ru.yanus171.feedexfork.utils.PrefUtils.getString(
                 FontSelectPreference.KEY, FontSelectPreference.DefaultFontFamily);
-        return fontName != null && !fontName.equals(FontSelectPreference.DefaultFontFamily);
+        boolean customFont = fontName != null
+                && !fontName.equals(FontSelectPreference.DefaultFontFamily);
+        // HtmlUtils.replaceImageURLs rewrites <img src> to file://<cached path>
+        // when downloaded images are displayed, so the WebView needs to load
+        // file:// URLs to render inline cached images.
+        boolean displayImages = ru.yanus171.feedexfork.utils.PrefUtils
+                .getBoolean(ru.yanus171.feedexfork.utils.PrefUtils.DISPLAY_IMAGES, true);
+        return customFont || displayImages;
     }
     private static final int CLICK_ON_WEBVIEW = 1;
     private static final int CLICK_ON_URL = 2;
@@ -140,12 +148,13 @@ public class WebViewExtended extends WebView implements Handler.Callback {
 
         Timer timer = new Timer("EntryView.init");
 
-        // Only enable file:// access when the user has actually picked a
-        // custom font that lives outside the bundled assets. In the default
-        // case the WebView only renders the article HTML built locally and
-        // does not need file URL access. android_asset URLs work either
-        // way.
-        getSettings().setAllowFileAccess(NeedsFileAccessForCustomFont());
+        // Enable file:// access only when a feature on this WebView depends on
+        // it: a user-picked custom font (loaded via @font-face from device
+        // storage) or downloaded image display (HtmlUtils rewrites <img src>
+        // to file://<cached path>). When neither is in use, the article HTML
+        // is rendered from in-memory content with no file:// references and
+        // the flag is unneeded. android_asset URLs work either way.
+        getSettings().setAllowFileAccess(NeedsFileAccess());
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1)
             setTextDirection(TEXT_DIRECTION_LOCALE);
         // For scrolling

--- a/FlymFork/src/main/java/ru/yanus171/feedexfork/view/WebViewExtended.java
+++ b/FlymFork/src/main/java/ru/yanus171/feedexfork/view/WebViewExtended.java
@@ -98,6 +98,12 @@ public class WebViewExtended extends WebView implements Handler.Callback {
     static final String TEXT_HTML = "text/html";
     public static final String NO_MENU = "NO_MENU_";
     public static final String BASE_URL = "";
+
+    private static boolean NeedsFileAccessForCustomFont() {
+        String fontName = ru.yanus171.feedexfork.utils.PrefUtils.getString(
+                FontSelectPreference.KEY, FontSelectPreference.DefaultFontFamily);
+        return fontName != null && !fontName.equals(FontSelectPreference.DefaultFontFamily);
+    }
     private static final int CLICK_ON_WEBVIEW = 1;
     private static final int CLICK_ON_URL = 2;
     private static final int TOGGLE_TAP_ZONE_VISIBIILTY = 3;
@@ -134,7 +140,12 @@ public class WebViewExtended extends WebView implements Handler.Callback {
 
         Timer timer = new Timer("EntryView.init");
 
-        getSettings().setAllowFileAccess(true);
+        // Only enable file:// access when the user has actually picked a
+        // custom font that lives outside the bundled assets. In the default
+        // case the WebView only renders the article HTML built locally and
+        // does not need file URL access. android_asset URLs work either
+        // way.
+        getSettings().setAllowFileAccess(NeedsFileAccessForCustomFont());
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1)
             setTextDirection(TEXT_DIRECTION_LOCALE);
         // For scrolling


### PR DESCRIPTION
Closes #989.

`WebViewExtended.init()` enables `setAllowFileAccess(true)` unconditionally while also attaching two JS bridges (`mInjectedJSObject`, `mImageDownloadObject`). The article HTML is then loaded with `loadDataWithBaseURL(BASE_URL = "", ...)`, so the WebView itself never points at a `file://` URL.

The only real consumer of file URL access is the custom-font path. When the user has picked a font other than `FontSelectPreference.DefaultFontFamily`, `WebEntryContent` injects:

```css
@font-face { font-family: "MainFont"; src: url("file://<getFontsFolder>/<fontName>"); }
```

That genuinely needs `setAllowFileAccess(true)`. For users on the default font the flag is dead.

### Change

Add a tiny helper and gate the flag on the actual preference:

```java
private static boolean NeedsFileAccessForCustomFont() {
    String fontName = PrefUtils.getString(
            FontSelectPreference.KEY, FontSelectPreference.DefaultFontFamily);
    return fontName != null && !fontName.equals(FontSelectPreference.DefaultFontFamily);
}

// in init():
getSettings().setAllowFileAccess(NeedsFileAccessForCustomFont());
```

### Behaviour

- Custom-font users: identical to before (flag on).
- Default-font users: WebView now has file URL access disabled on pre-API-30 devices, not inheriting the legacy default-on value.
- Bundled fonts under `file:///android_asset/FontsDir/` keep working, since the `android_asset` scheme is permitted regardless of this flag.

The change is contained to `WebViewExtended.java`. No callers need to update.